### PR TITLE
feat:[001-Member]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,12 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	implementation("org.springframework.boot:spring-boot-starter-webflux")
 	implementation 'org.json:json:20230227'
-	implementation 'io.springfox:springfox-boot-starter'
+
+	// member
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	testImplementation 'org.springframework.security:spring-security-test'
+	implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.1'
+	implementation 'org.springframework.boot:spring-boot-starter-validation:3.1.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/backend/TravelGuide/TravelGuideApplication.java
+++ b/src/main/java/com/backend/TravelGuide/TravelGuideApplication.java
@@ -2,7 +2,9 @@ package com.backend.TravelGuide;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class TravelGuideApplication {
 

--- a/src/main/java/com/backend/TravelGuide/member/Test.java
+++ b/src/main/java/com/backend/TravelGuide/member/Test.java
@@ -1,4 +1,0 @@
-package com.backend.TravelGuide.member;
-
-public class Test {
-}

--- a/src/main/java/com/backend/TravelGuide/member/config/SecurityConfig.java
+++ b/src/main/java/com/backend/TravelGuide/member/config/SecurityConfig.java
@@ -1,0 +1,44 @@
+package com.backend.TravelGuide.member.config;
+
+import com.backend.TravelGuide.member.security.JwtCheckFilter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@EnableGlobalMethodSecurity(prePostEnabled = true, securedEnabled = true)
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    @Bean
+    PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManagerBean() throws Exception {
+        return super.authenticationManagerBean();
+    }
+
+    @Autowired
+    private JwtCheckFilter jwtCheckFilter;
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http.cors().disable();
+        http.httpBasic().disable()
+                        .csrf().disable()
+                        .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                        .and()
+                            .addFilterBefore(jwtCheckFilter, UsernamePasswordAuthenticationFilter.class);
+    }
+}

--- a/src/main/java/com/backend/TravelGuide/member/controller/LoginController.java
+++ b/src/main/java/com/backend/TravelGuide/member/controller/LoginController.java
@@ -1,0 +1,37 @@
+package com.backend.TravelGuide.member.controller;
+
+import com.backend.TravelGuide.member.domain.MemberRequestDTO;
+import com.backend.TravelGuide.member.service.impl.LoginServiceImpl;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/login")
+@RequiredArgsConstructor
+public class LoginController {
+    private final LoginServiceImpl loginService;
+
+    @PostMapping("/kakao")
+    public ResponseEntity<String> kakaoLoginJs(@RequestBody MemberRequestDTO.KakaoLoginDTO loginDto) throws Exception {
+        log.info(">> 카카오 회원 로그인");
+
+        String token = loginService.kakaoLogin(loginDto);
+
+        return ResponseEntity.ok().body(token);
+    }
+
+    @PostMapping("/normal")
+    public ResponseEntity<String> login(@RequestBody MemberRequestDTO.MemberLoginDTO loginDTO) {
+        log.info(">> 일반 회원 로그인");
+
+        String token = loginService.normalLogin(loginDTO);
+
+        return ResponseEntity.ok().body(token);
+    }
+}

--- a/src/main/java/com/backend/TravelGuide/member/controller/MemberController.java
+++ b/src/main/java/com/backend/TravelGuide/member/controller/MemberController.java
@@ -1,0 +1,95 @@
+package com.backend.TravelGuide.member.controller;
+
+import com.backend.TravelGuide.member.domain.MemberRequestDTO;
+import com.backend.TravelGuide.member.domain.MemberResponseDTO;
+import com.backend.TravelGuide.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.security.Principal;
+
+@Slf4j
+@RestController
+@RequestMapping("/member")
+@RequiredArgsConstructor
+public class MemberController {
+    private final MemberService memberService;
+
+    // 회원가입
+    @PostMapping("/join")
+    public ResponseEntity<Void> join(@Valid @RequestBody MemberRequestDTO.MemberJoinDTO joinDTO) {
+        memberService.join(joinDTO);
+
+        return ResponseEntity.ok().build();
+    }
+
+    // jwt(x)
+    // 비밀번호 찾기 질문의 답변 매칭
+    @GetMapping("/checkAnswer")
+    public ResponseEntity<Boolean> checkAnswer(@Valid @RequestBody MemberRequestDTO.CheckAnswerDTO checkAnswerDTO) {
+        boolean result = memberService.checkAnswer(checkAnswerDTO);
+
+        return ResponseEntity.ok().body(result);    // true(알맞은 답변), false(틀린 답변)
+    }
+
+    // jwt(x)
+    // 비밀번호 찾기 -> 새 비밀번호 입력
+    @PostMapping("/newPassword")
+    public ResponseEntity<Void> setNewPassword(@Valid @RequestBody MemberRequestDTO.NewPasswordDTO newPasswordDTO) {
+        memberService.setNewPassword(newPasswordDTO);
+
+        return ResponseEntity.ok().build();
+    }
+
+    // 사용자 정보 조회
+    @GetMapping("/info")
+    @PreAuthorize("hasRole('USER')")
+    public ResponseEntity<MemberResponseDTO.MemberInformationDTO> info(Principal principal) {
+        MemberResponseDTO.MemberInformationDTO infoDTO
+                = memberService.searchInfo(principal.getName());
+
+        return ResponseEntity.ok().body(infoDTO);
+    }
+
+    // 사용자 정보 업데이트
+    @PutMapping("/update")
+    @PreAuthorize("hasRole('USER')")
+    public ResponseEntity<Void> update(@Valid @RequestBody MemberRequestDTO.UpdateInfoDTO infoDTO, Principal principal) {
+        infoDTO.setEmail(principal.getName());
+        memberService.updateInfo(infoDTO);
+
+        return ResponseEntity.ok().build();
+    }
+
+    // 비밀번호 초기화
+    @PutMapping("/password_reset")
+    @PreAuthorize("hasRole('USER')")
+    public ResponseEntity<Void> resetPassword(@Valid @RequestBody MemberRequestDTO.ResetPwdDTO resetPwdDTO, Principal principal) {
+        resetPwdDTO.setEmail(principal.getName());
+        memberService.resetPassword(resetPwdDTO);
+
+        return ResponseEntity.ok().build();
+    }
+
+    // 회원탈퇴
+    @DeleteMapping("/withdraw")
+    @PreAuthorize("hasRole('USER')")
+    public ResponseEntity<Void> withdraw(@Valid @RequestBody MemberRequestDTO.WithdrawDTO withdrawDTO, Principal principal) {
+        withdrawDTO.setEmail(principal.getName());
+        memberService.withdraw(withdrawDTO);
+
+        return ResponseEntity.ok().build();
+    }
+
+    // 이메일/닉네임 중복검사
+    @GetMapping("/duplication")
+    public ResponseEntity<Boolean> isDuplicated(@Valid @RequestBody MemberRequestDTO.CheckDuplicationDTO duplicationDTO) {
+        boolean result = memberService.isDuplicated(duplicationDTO);
+
+        return ResponseEntity.ok().body(result);
+    }
+}

--- a/src/main/java/com/backend/TravelGuide/member/domain/BaseEntity.java
+++ b/src/main/java/com/backend/TravelGuide/member/domain/BaseEntity.java
@@ -1,0 +1,22 @@
+package com.backend.TravelGuide.member.domain;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
+}

--- a/src/main/java/com/backend/TravelGuide/member/domain/Member.java
+++ b/src/main/java/com/backend/TravelGuide/member/domain/Member.java
@@ -1,0 +1,41 @@
+package com.backend.TravelGuide.member.domain;
+
+import lombok.*;
+
+import javax.persistence.*;
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+@Builder
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString(exclude = "answers")
+public class Member extends BaseEntity {
+    @Id
+    private String email;
+
+    private String password;
+
+    private String name;
+
+    private String nickname;
+
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    private boolean fromSocial;
+
+    // 비밀번호 초기화 질문에 대한 대답
+    @ElementCollection(fetch = FetchType.LAZY)
+    Map<Integer, String> answers = new HashMap<>();
+
+    public void updateInfo(MemberRequestDTO.UpdateInfoDTO updateInfoDTO) {
+        this.nickname = updateInfoDTO.getNickname();
+    }
+
+    public void resetPwd(String newPassword) {
+        this.password = newPassword;
+    }
+}

--- a/src/main/java/com/backend/TravelGuide/member/domain/MemberDTO.java
+++ b/src/main/java/com/backend/TravelGuide/member/domain/MemberDTO.java
@@ -1,0 +1,31 @@
+package com.backend.TravelGuide.member.domain;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+
+import java.util.Collection;
+
+@Getter
+@Setter
+@ToString
+public class MemberDTO extends User {
+    private String email;
+    private String password;
+    private String name;
+    private boolean fromSocial;
+
+    // User 상속 후 생성자 생성 필수
+    // password는 User 부모클래스를 사용하므로 멤버변수로 선언하지 않는다
+    public MemberDTO(String username,
+                     String password,
+                     boolean fromSocial,
+                     Collection<? extends GrantedAuthority> authorities) {
+        super(username, password, authorities);
+        this.email = username;
+        this.password = password;   // password를 넘겨주면 passwordEncoder가 자동으로 검사해줌
+        this.fromSocial = fromSocial;
+    }
+}

--- a/src/main/java/com/backend/TravelGuide/member/domain/MemberRequestDTO.java
+++ b/src/main/java/com/backend/TravelGuide/member/domain/MemberRequestDTO.java
@@ -1,0 +1,151 @@
+package com.backend.TravelGuide.member.domain;
+
+import lombok.*;
+
+import javax.validation.constraints.*;
+import java.util.ArrayList;
+import java.util.List;
+
+public class MemberRequestDTO {
+
+    @Getter
+    @Setter
+    @Builder
+    @ToString
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class KakaoLoginDTO {
+        private String email;
+        private String nickname;
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @ToString
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MemberLoginDTO {
+        @Email(message = "아이디는 이메일 형식입니다")
+        private String email;
+
+        @Size(min = 8, message = "비밀번호는 최소 8자입니다")
+        private String password;
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @ToString
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MemberJoinDTO {
+        @Email(message = "아이디는 이메일 형식입니다")
+        private String email;
+
+        @Size(min = 8, message = "비밀번호는 최소 8자입니다")
+        @Pattern(regexp = "^[a-zA-Z0-9]*$", message = "영문과 숫자만 가능합니다.")
+        private String password;
+
+        @NotBlank(message = "이름은 필수 입력란입니다")
+        private String name;
+
+        @NotBlank(message = "닉네임은 필수 입력란입니다")
+        private String nickname;
+
+        @NotEmpty(message = "답을 입력해주셔야 합니다")
+        @Size(min = 3, message = "3개의 답을 모두 작성해주셔야 합니다")
+        private List<String> answers = new ArrayList<>();
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @ToString
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UpdateInfoDTO {
+        @Email(message = "아이디는 이메일 형식입니다")
+        private String email;
+
+        @NotBlank(message = "이름은 필수 입력란입니다")
+        private String name;
+
+        @NotBlank(message = "이름은 필수 입력란입니다")
+        private String nickname;
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @ToString
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ResetPwdDTO {
+        @Email(message = "아이디는 이메일 형식입니다")
+        private String email;
+
+        @Size(min = 8, message = "비밀번호는 최소 8자입니다")
+        @Pattern(regexp = "^[a-zA-Z0-9]*$", message = "영문과 숫자만 가능합니다.")
+        private String oldPassword;
+
+        @Size(min = 8, message = "비밀번호는 최소 8자입니다")
+        @Pattern(regexp = "^[a-zA-Z0-9]*$", message = "영문과 숫자만 가능합니다.")
+        private String newPassword;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @ToString
+    public static class CheckAnswerDTO {
+        @Email(message = "아이디는 이메일 형식입니다")
+        private String email;
+
+        @NotBlank(message = "이름은 필수 입력란입니다")
+        private String name;
+
+        private int questionId;
+        private String answer;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @ToString
+    public static class NewPasswordDTO {
+        private String email;
+        private String newPassword;
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @ToString
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class WithdrawDTO {
+        @Email(message = "아이디는 이메일 형식입니다")
+        private String email;
+
+        @Size(min = 8, message = "비밀번호는 최소 8자입니다")
+        @Pattern(regexp = "^[a-zA-Z0-9]*$", message = "영문과 숫자만 가능합니다.")
+        private String password;
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @ToString
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CheckDuplicationDTO {
+        @Email(message = "아이디는 이메일 형식입니다")
+        private String email;
+        private String nickname;
+    }
+}

--- a/src/main/java/com/backend/TravelGuide/member/domain/MemberResponseDTO.java
+++ b/src/main/java/com/backend/TravelGuide/member/domain/MemberResponseDTO.java
@@ -1,0 +1,18 @@
+package com.backend.TravelGuide.member.domain;
+
+import lombok.*;
+
+public class MemberResponseDTO {
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @ToString
+    public static class MemberInformationDTO {
+        private String email;
+        private String name;
+        private String nickname;
+    }
+}

--- a/src/main/java/com/backend/TravelGuide/member/domain/Role.java
+++ b/src/main/java/com/backend/TravelGuide/member/domain/Role.java
@@ -1,0 +1,5 @@
+package com.backend.TravelGuide.member.domain;
+
+public enum Role {
+    USER, ADMIN
+}

--- a/src/main/java/com/backend/TravelGuide/member/error/CustomExceptionHandler.java
+++ b/src/main/java/com/backend/TravelGuide/member/error/CustomExceptionHandler.java
@@ -1,0 +1,60 @@
+package com.backend.TravelGuide.member.error;
+
+import com.backend.TravelGuide.member.error.exception.CustomException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+@Slf4j
+@Component
+@RestControllerAdvice
+public class CustomExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ErrorResponse> methodArgumentNotValidExceptionHandler(MethodArgumentNotValidException e) {
+        List<String> errorMessages = new ArrayList<>();
+        for (FieldError fieldError : e.getBindingResult().getFieldErrors()) {
+            String errorMessage = fieldError.getDefaultMessage();
+            errorMessages.add(errorMessage);
+        }
+
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .statusCode(HttpStatus.BAD_REQUEST.value())
+                .messages(errorMessages)
+                .build();
+
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(UsernameNotFoundException.class)
+    protected ResponseEntity<ErrorResponse> usernameNotFoundExceptionHandler(UsernameNotFoundException e) {
+        ErrorResponse errorResponse = ErrorResponse
+                .builder()
+                .statusCode(HttpStatus.BAD_REQUEST.value())
+                .messages(Arrays.asList(e.getMessage()))
+                .build();
+
+        return new ResponseEntity<>(errorResponse, HttpStatus.resolve(HttpStatus.BAD_REQUEST.value()));
+    }
+
+    @ExceptionHandler(CustomException.class)
+    protected ResponseEntity<ErrorResponse> customExceptionHandler(CustomException e) {
+        ErrorResponse errorResponse = ErrorResponse
+                .builder()
+                .statusCode(e.getStatusCode())
+                .messages(Arrays.asList(e.getMessage()))
+                .build();
+
+        return new ResponseEntity<>(errorResponse, HttpStatus.resolve(e.getStatusCode()));
+    }
+}

--- a/src/main/java/com/backend/TravelGuide/member/error/ErrorResponse.java
+++ b/src/main/java/com/backend/TravelGuide/member/error/ErrorResponse.java
@@ -1,0 +1,15 @@
+package com.backend.TravelGuide.member.error;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ErrorResponse {
+    private int statusCode;
+    private List<String> messages;
+}

--- a/src/main/java/com/backend/TravelGuide/member/error/exception/CustomException.java
+++ b/src/main/java/com/backend/TravelGuide/member/error/exception/CustomException.java
@@ -1,0 +1,6 @@
+package com.backend.TravelGuide.member.error.exception;
+
+public abstract class CustomException extends RuntimeException{
+    abstract public int getStatusCode();
+    abstract public String getMessage();
+}

--- a/src/main/java/com/backend/TravelGuide/member/error/exception/NoJwtTokenException.java
+++ b/src/main/java/com/backend/TravelGuide/member/error/exception/NoJwtTokenException.java
@@ -1,0 +1,15 @@
+package com.backend.TravelGuide.member.error.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class NoJwtTokenException extends CustomException{
+    @Override
+    public int getStatusCode() {
+        return HttpStatus.BAD_REQUEST.value();
+    }
+
+    @Override
+    public String getMessage() {
+        return "Jwt토큰을 전달받지 못했습니다!";
+    }
+}

--- a/src/main/java/com/backend/TravelGuide/member/error/exception/PasswordNotMatchException.java
+++ b/src/main/java/com/backend/TravelGuide/member/error/exception/PasswordNotMatchException.java
@@ -1,0 +1,15 @@
+package com.backend.TravelGuide.member.error.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class PasswordNotMatchException extends CustomException{
+    @Override
+    public int getStatusCode() {
+        return HttpStatus.BAD_REQUEST.value();
+    }
+
+    @Override
+    public String getMessage() {
+        return "비밀번호가 일치하지 않습니다!";
+    }
+}

--- a/src/main/java/com/backend/TravelGuide/member/error/exception/UserAlreadyExistsException.java
+++ b/src/main/java/com/backend/TravelGuide/member/error/exception/UserAlreadyExistsException.java
@@ -1,0 +1,15 @@
+package com.backend.TravelGuide.member.error.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class UserAlreadyExistsException extends CustomException{
+    @Override
+    public int getStatusCode() {
+        return HttpStatus.BAD_REQUEST.value();
+    }
+
+    @Override
+    public String getMessage() {
+        return "이미 존재하는 아이디입니다!";
+    }
+}

--- a/src/main/java/com/backend/TravelGuide/member/error/exception/UserNotMatchException.java
+++ b/src/main/java/com/backend/TravelGuide/member/error/exception/UserNotMatchException.java
@@ -1,0 +1,15 @@
+package com.backend.TravelGuide.member.error.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class UserNotMatchException extends CustomException {
+    @Override
+    public int getStatusCode() {
+        return HttpStatus.BAD_REQUEST.value();
+    }
+
+    @Override
+    public String getMessage() {
+        return "로그인한 사용자와 불일치합니다";
+    }
+}

--- a/src/main/java/com/backend/TravelGuide/member/repository/MemberRepository.java
+++ b/src/main/java/com/backend/TravelGuide/member/repository/MemberRepository.java
@@ -1,0 +1,14 @@
+package com.backend.TravelGuide.member.repository;
+
+import com.backend.TravelGuide.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, String> {
+    boolean existsByEmail(String email);
+    boolean existsByNickname(String nickname);
+    Optional<Member> findByEmail(String email);
+    Optional<Member> findByEmailAndName(String email, String name);
+    Optional<Member> findByEmailAndFromSocial(String email, boolean fromSocial);
+}

--- a/src/main/java/com/backend/TravelGuide/member/security/JwtCheckFilter.java
+++ b/src/main/java/com/backend/TravelGuide/member/security/JwtCheckFilter.java
@@ -1,0 +1,67 @@
+package com.backend.TravelGuide.member.security;
+
+import com.backend.TravelGuide.member.error.exception.NoJwtTokenException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Arrays;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtCheckFilter extends OncePerRequestFilter {
+    public static final String TOKEN_HEADER = "Authorization";
+    public static final String TOKEN_PREFIX = "Bearer ";
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws ServletException, IOException {
+        log.info(">>> JwtCheckFilter");
+
+        String token = resolveTokenFromRequest(request);
+
+        if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
+            Authentication authentication = jwtTokenProvider.getAuthentication(token);
+
+            log.info(String.format("[%s] -> %s", jwtTokenProvider.getUsername(token), request.getRequestURI()));
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        } else {
+            throw new NoJwtTokenException();
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveTokenFromRequest(HttpServletRequest request) {
+        String token = request.getHeader(TOKEN_HEADER);
+
+        if (!ObjectUtils.isEmpty(token) && token.startsWith(TOKEN_PREFIX)) {
+            return token.substring(TOKEN_PREFIX.length());
+        }
+
+        return null;
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String[] excludePath = {"/user", "/login", "/member/join", "/member/checkAnswer", "/member/newPassword", "/member/duplication", "/swagger", "/v2"};
+        String path = request.getRequestURI();
+        return Arrays.stream(excludePath).anyMatch(path::startsWith);
+    }
+}

--- a/src/main/java/com/backend/TravelGuide/member/security/JwtTokenProvider.java
+++ b/src/main/java/com/backend/TravelGuide/member/security/JwtTokenProvider.java
@@ -1,0 +1,73 @@
+package com.backend.TravelGuide.member.security;
+
+import com.backend.TravelGuide.member.service.MemberDetailsService;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.util.Date;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+    private final MemberDetailsService memberDetailsService;
+
+    private static final String KEY_ROLES = "roles";
+
+    @Value("{spring.jwt.secret}")
+    private String secretKey;
+
+    public String generateToken(String username, List<SimpleGrantedAuthority> roles, Long time) {
+        Claims claims = Jwts.claims().setSubject(username);
+        claims.put(KEY_ROLES, roles);
+
+        Date now = new Date();
+        Date expiredDate = new Date(now.getTime() + time);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(expiredDate)
+                .signWith(SignatureAlgorithm.HS512, this.secretKey)
+                .compact();
+    }
+
+    public Authentication getAuthentication(String jwt) {
+        UserDetails userDetails = this.memberDetailsService.loadUserByUsername(getUsername(jwt));
+        return new UsernamePasswordAuthenticationToken(userDetails, ""
+                , userDetails.getAuthorities());
+    }
+
+    public String getUsername(String token) {
+        return this.parseClaims(token).getSubject();
+    }
+
+    public boolean validateToken(String token) {
+        if (!StringUtils.hasText(token))
+            return false;
+
+        Claims claims = parseClaims(token);
+        return !claims.getExpiration().before(new Date());
+    }
+
+    private Claims parseClaims(String token) {
+        try {
+            return Jwts.parser()
+                    .setSigningKey(this.secretKey)
+                    .parseClaimsJws(token)
+                    .getBody();
+        } catch(ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+}

--- a/src/main/java/com/backend/TravelGuide/member/service/LoginService.java
+++ b/src/main/java/com/backend/TravelGuide/member/service/LoginService.java
@@ -1,0 +1,14 @@
+package com.backend.TravelGuide.member.service;
+
+import com.backend.TravelGuide.member.domain.Member;
+import com.backend.TravelGuide.member.domain.MemberRequestDTO;
+
+public interface LoginService {
+    Member saveKakaoMemberIfNotExists(MemberRequestDTO.KakaoLoginDTO loginDTO)throws Exception;
+
+    String kakaoLogin(MemberRequestDTO.KakaoLoginDTO loginDTO) throws Exception;
+
+    String normalLogin(MemberRequestDTO.MemberLoginDTO loginDTO) throws Exception;
+
+    void authenticate(String username, String pwd) throws Exception;
+}

--- a/src/main/java/com/backend/TravelGuide/member/service/MemberDetailsService.java
+++ b/src/main/java/com/backend/TravelGuide/member/service/MemberDetailsService.java
@@ -1,0 +1,56 @@
+package com.backend.TravelGuide.member.service;
+
+import com.backend.TravelGuide.member.domain.Member;
+import com.backend.TravelGuide.member.domain.MemberDTO;
+import com.backend.TravelGuide.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MemberDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        log.info(">> MemberDetailsService loadUserByUsername: " + username);
+
+        Optional<Member> optionalMember = memberRepository.findByEmailAndFromSocial(username, true);
+
+        if (!optionalMember.isPresent()) {
+            optionalMember = memberRepository.findByEmailAndFromSocial(username, false);
+        }
+
+        if (!optionalMember.isPresent()) {
+            throw new UsernameNotFoundException("Check your email or pwd");
+        }
+
+        Member member = optionalMember.get();
+        log.info(">> member: " + member);
+
+        List<SimpleGrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority("ROLE_" + member.getRole().name()));
+        MemberDTO memberDTO = new MemberDTO(
+                member.getEmail(),
+                member.getPassword(),
+                member.isFromSocial(),
+                authorities
+        );
+
+        memberDTO.setName(member.getName());
+        memberDTO.setFromSocial(member.isFromSocial());
+
+        return memberDTO;
+    }
+}

--- a/src/main/java/com/backend/TravelGuide/member/service/MemberService.java
+++ b/src/main/java/com/backend/TravelGuide/member/service/MemberService.java
@@ -1,0 +1,36 @@
+package com.backend.TravelGuide.member.service;
+
+import com.backend.TravelGuide.member.domain.MemberRequestDTO;
+import com.backend.TravelGuide.member.domain.MemberResponseDTO;
+
+public interface MemberService {
+    // 일반회원가입
+    void join(MemberRequestDTO.MemberJoinDTO joinDTO);
+
+    // 회원정보조회
+    MemberResponseDTO.MemberInformationDTO searchInfo(String email);
+
+    // 회원정보수정
+    void updateInfo(MemberRequestDTO.UpdateInfoDTO updateInfoDTO);
+
+    // 비밀번호 초기화
+    void resetPassword(MemberRequestDTO.ResetPwdDTO resetPwdDTO);
+
+    // 비밀번호 찾기 질문의 답변
+    Boolean checkAnswer(MemberRequestDTO.CheckAnswerDTO checkAnswerDTO);
+
+    // 비밀번호 찾기 후 새 비밀번호 세팅
+    void setNewPassword(MemberRequestDTO.NewPasswordDTO newPasswordDTO);
+
+    // 회원탈퇴
+    void withdraw(MemberRequestDTO.WithdrawDTO withdrawDTO);
+
+    // 이메일/닉네임 중복 확인
+    boolean isDuplicated(MemberRequestDTO.CheckDuplicationDTO duplicationDTO);
+
+    // TODO 내 플래너 목록
+
+    // TODO 내 게시글 목록
+
+    // TODO 내 댓글 목록
+}

--- a/src/main/java/com/backend/TravelGuide/member/service/impl/LoginServiceImpl.java
+++ b/src/main/java/com/backend/TravelGuide/member/service/impl/LoginServiceImpl.java
@@ -1,0 +1,112 @@
+package com.backend.TravelGuide.member.service.impl;
+
+import com.backend.TravelGuide.member.domain.Member;
+import com.backend.TravelGuide.member.domain.MemberRequestDTO;
+import com.backend.TravelGuide.member.domain.Role;
+import com.backend.TravelGuide.member.error.exception.PasswordNotMatchException;
+import com.backend.TravelGuide.member.repository.MemberRepository;
+import com.backend.TravelGuide.member.security.JwtTokenProvider;
+import com.backend.TravelGuide.member.service.LoginService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.DisabledException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LoginServiceImpl implements LoginService {
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider tokenProvider;
+    private final AuthenticationManager authenticationManager;
+
+    private static final long TOKEN_EXPIRE_TIME = 1000 * 60 * 60;
+    private static final String TOKEN_PREFIX = "Bearer ";
+
+    public Member saveKakaoMemberIfNotExists(MemberRequestDTO.KakaoLoginDTO loginDto) {
+        Optional<Member> optionalMember = memberRepository.findByEmailAndFromSocial(loginDto.getEmail(), true);
+
+        // 처음 로그인하는 경우
+        if (optionalMember.isEmpty()) {
+            Member member = Member.builder()
+                    .email(loginDto.getEmail())
+                    .name(loginDto.getNickname())
+                    .role(Role.USER)
+                    .password(passwordEncoder.encode("1111"))
+                    .fromSocial(true)
+                    .build();
+
+            memberRepository.save(member);
+
+            return member;
+        }
+
+        return null;
+    }
+
+    public String kakaoLogin(MemberRequestDTO.KakaoLoginDTO loginDto) throws Exception {
+        Member member = saveKakaoMemberIfNotExists(loginDto);
+
+        List<SimpleGrantedAuthority> roles =
+                Arrays.asList(new SimpleGrantedAuthority("ROLE_" + member.getRole()));
+
+        String jwt = TOKEN_PREFIX + tokenProvider.generateToken(member.getEmail(), roles, TOKEN_EXPIRE_TIME);
+
+        log.info(">> 소셜 로그인 JWT 토큰: " + jwt);
+
+        authenticate(member.getEmail(), "11111111");
+
+        return jwt;
+    }
+
+    public String normalLogin(MemberRequestDTO.MemberLoginDTO loginDTO) {
+        Optional<Member> optionalMember = memberRepository.findByEmailAndFromSocial(loginDTO.getEmail(), false);
+
+        if (!optionalMember.isPresent()) {
+            throw new UsernameNotFoundException("존재하지 않는 회원입니다!");
+        }
+
+        Member member = optionalMember.get();
+
+        if (!passwordEncoder.matches(loginDTO.getPassword(), member.getPassword())) {
+            throw new PasswordNotMatchException();
+        }
+
+        List<SimpleGrantedAuthority> roles =
+                Arrays.asList(new SimpleGrantedAuthority("ROLE_" + member.getRole()));
+
+        String jwt = TOKEN_PREFIX + tokenProvider.generateToken(loginDTO.getEmail(), roles, TOKEN_EXPIRE_TIME);
+
+        log.info(">> 일반 로그인 JWT 토큰: " + jwt);
+
+        return jwt;
+    }
+
+    public void authenticate(String username, String pwd) throws Exception {
+        try {
+            log.info(">> 강제 로그인 처리 ");
+
+            Authentication authentication = authenticationManager.authenticate(
+                    new UsernamePasswordAuthenticationToken(username, pwd));
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        } catch (DisabledException e) {
+            throw new Exception("USER_DISABLED", e);
+        } catch (BadCredentialsException e) {
+            throw new Exception("INVALID_CREDENTIALS", e);
+        }
+    }
+}

--- a/src/main/java/com/backend/TravelGuide/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/backend/TravelGuide/member/service/impl/MemberServiceImpl.java
@@ -1,0 +1,158 @@
+package com.backend.TravelGuide.member.service.impl;
+
+import com.backend.TravelGuide.member.domain.Member;
+import com.backend.TravelGuide.member.domain.MemberRequestDTO;
+import com.backend.TravelGuide.member.domain.MemberResponseDTO;
+import com.backend.TravelGuide.member.domain.Role;
+import com.backend.TravelGuide.member.error.exception.UserAlreadyExistsException;
+import com.backend.TravelGuide.member.error.exception.PasswordNotMatchException;
+import com.backend.TravelGuide.member.error.exception.UserNotMatchException;
+import com.backend.TravelGuide.member.repository.MemberRepository;
+import com.backend.TravelGuide.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.Principal;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MemberServiceImpl implements MemberService {
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    @Transactional
+    public void join(MemberRequestDTO.MemberJoinDTO joinDTO) {
+        if (memberRepository.existsByEmail(joinDTO.getEmail())) {
+            throw new UserAlreadyExistsException();
+        }
+
+        int idx = 1;
+        HashMap<Integer, String> map = new HashMap<>();
+        for (String answer : joinDTO.getAnswers()) {
+            map.put(idx++, answer);
+        }
+
+        Member member = Member.builder()
+                .email(joinDTO.getEmail())
+                .password(passwordEncoder.encode(joinDTO.getPassword()))
+                .name(joinDTO.getName())
+                .nickname(joinDTO.getNickname())
+                .role(Role.USER)
+                .fromSocial(false)
+                .answers(map)
+                .build();
+
+        Member savedMember = memberRepository.save(member);
+
+        log.info("회원가입에 성공했습니다 -> " + savedMember);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public MemberResponseDTO.MemberInformationDTO searchInfo(String email) {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 회원입니다!"));
+
+        return MemberResponseDTO.MemberInformationDTO.builder()
+                .email(member.getEmail())
+                .name(member.getName())
+                .nickname(member.getNickname())
+                .build();
+    }
+
+    @Override
+    @Transactional
+    public void updateInfo(MemberRequestDTO.UpdateInfoDTO updateInfoDTO) {
+        Member member = memberRepository.findByEmail(updateInfoDTO.getEmail())
+                .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 회원입니다!"));
+
+        member.updateInfo(updateInfoDTO);
+
+        Member updateMember = memberRepository.save(member);
+        log.info("회원정보 수정에 성공하였습니다! -> " + updateMember);
+    }
+
+    @Override
+    @Transactional
+    public void resetPassword(MemberRequestDTO.ResetPwdDTO resetPwdDTO) {
+        Member member = memberRepository.findByEmail(resetPwdDTO.getEmail())
+                .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 회원입니다!"));
+
+        if (!passwordEncoder.matches(resetPwdDTO.getOldPassword(), member.getPassword())) {
+            throw new PasswordNotMatchException();
+        }
+
+        String newPassword = passwordEncoder.encode(resetPwdDTO.getNewPassword());
+
+        member.resetPwd(newPassword);
+
+        memberRepository.save(member);
+        log.info("비밀번호 초기화에 성공하였습니다!");
+    }
+
+    @Override
+    @Transactional
+    public Boolean checkAnswer(MemberRequestDTO.CheckAnswerDTO checkAnswerDTO) {
+        Member member = memberRepository.findByEmailAndName(checkAnswerDTO.getEmail(), checkAnswerDTO.getName())
+                .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 회원입니다!"));
+
+        Map<Integer, String> answers = member.getAnswers();
+        String answer = answers.get(checkAnswerDTO.getQuestionId());
+
+        return answer.equals(checkAnswerDTO.getAnswer());
+    }
+
+    @Override
+    @Transactional
+    public void setNewPassword(MemberRequestDTO.NewPasswordDTO newPasswordDTO) {
+        Member member = memberRepository.findByEmail(newPasswordDTO.getEmail())
+                .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 회원입니다!"));
+
+        String encPassword = passwordEncoder.encode(newPasswordDTO.getNewPassword());
+
+        member.resetPwd(encPassword);
+
+        memberRepository.save(member);
+
+        log.info("비밀번호를 새로 생성하였습니다!");
+    }
+
+    @Override
+    @Transactional
+    public void withdraw(MemberRequestDTO.WithdrawDTO withdrawDTO) {
+        Member member = memberRepository.findByEmail(withdrawDTO.getEmail())
+                .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 회원입니다!"));
+
+        if (!passwordEncoder.matches(withdrawDTO.getPassword(), member.getPassword())) {
+            throw new PasswordNotMatchException();
+        }
+
+        memberRepository.delete(member);
+        log.info(member.getEmail() + " 님의 회원탈퇴에 성공하였습니다!");
+    }
+
+    @Override
+    @Transactional
+    public boolean isDuplicated(MemberRequestDTO.CheckDuplicationDTO duplicationDTO) {
+        // 존재하지 않는 닉네임일 경우 false 반환
+        if (duplicationDTO.getNickname() != null && !duplicationDTO.getNickname().equals("")) {
+            return !memberRepository.existsByNickname(duplicationDTO.getNickname());
+        }
+
+        // 존재하지 않는 이메일일 경우 false 반환
+        if (duplicationDTO.getEmail() != null && !duplicationDTO.getEmail().equals("")) {
+            return !memberRepository.existsByEmail(duplicationDTO.getEmail());
+        }
+
+        return true;    // true : 중복검사 통과
+    }
+}

--- a/src/test/java/com/backend/TravelGuide/member/LoginHttpTest.http
+++ b/src/test/java/com/backend/TravelGuide/member/LoginHttpTest.http
@@ -1,0 +1,17 @@
+### 카카오 로그인
+POST http://localhost:8080/login/kakao
+Content-Type: application/json
+
+{
+  "email": "user@email.com",
+  "nickname": "user"
+}
+
+### 일반 로그인
+POST http://localhost:8080/login/normal
+Content-Type: application/json
+
+{
+  "email": "user@email.com",
+  "password": "11111111"
+}

--- a/src/test/java/com/backend/TravelGuide/member/MemberHttpTest.http
+++ b/src/test/java/com/backend/TravelGuide/member/MemberHttpTest.http
@@ -1,0 +1,52 @@
+### 회원가입
+POST http://localhost:8080/member/join
+Content-Type: application/json
+
+{
+  "email" : "user@email.com",
+  "password" : "11111111",
+  "name" : "user1",
+  "answers" : [
+    "answer1",
+    "answer2",
+    "answer3"
+  ]
+}
+
+### 사용자 정보 조회
+GET http://localhost:8080/member/info
+Content-Type: application/json
+Authorization:Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ1c2VyQGVtYWlsLmNvbSIsInJvbGVzIjpbeyJhdXRob3JpdHkiOiJST0xFX0FETUlOIn1dLCJpYXQiOjE2OTEzMDcxNTYsImV4cCI6MTY5MTMxMDc1Nn0.yPrjbtNq5eVVI1rKzlgYI6K65x6LHzdLtwOdQuvH2SSO1z3Hly-y1u2oeBeE-Yt2xvxORRaxqNCDKaZfYQHnmA
+
+### 사용자 정보 업데이트
+PUT http://localhost:8080/member/update
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ1c2VyQGVtYWlsLmNvbSIsInJvbGVzIjpbeyJhdXRob3JpdHkiOiJST0xFX0FETUlOIn1dLCJpYXQiOjE2OTEzMDcxNTYsImV4cCI6MTY5MTMxMDc1Nn0.yPrjbtNq5eVVI1rKzlgYI6K65x6LHzdLtwOdQuvH2SSO1z3Hly-y1u2oeBeE-Yt2xvxORRaxqNCDKaZfYQHnmA
+
+{
+  "name": "modified user"
+}
+
+### 비밀번호 초기화 질문에 대한 대답 조회
+GET http://localhost:8080/member/password_answers
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ1c2VyQGVtYWlsLmNvbSIsInJvbGVzIjpbeyJhdXRob3JpdHkiOiJST0xFX0FETUlOIn1dLCJpYXQiOjE2OTEzMDcxNTYsImV4cCI6MTY5MTMxMDc1Nn0.yPrjbtNq5eVVI1rKzlgYI6K65x6LHzdLtwOdQuvH2SSO1z3Hly-y1u2oeBeE-Yt2xvxORRaxqNCDKaZfYQHnmA
+
+### 비밀번호 초기화
+PUT http://localhost:8080/member/password_reset
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ1c2VyQGVtYWlsLmNvbSIsInJvbGVzIjpbeyJhdXRob3JpdHkiOiJST0xFX0FETUlOIn1dLCJpYXQiOjE2OTEzMDcxNTYsImV4cCI6MTY5MTMxMDc1Nn0.yPrjbtNq5eVVI1rKzlgYI6K65x6LHzdLtwOdQuvH2SSO1z3Hly-y1u2oeBeE-Yt2xvxORRaxqNCDKaZfYQHnmA
+
+{
+  "oldPassword" : "11111111",
+  "newPassword" : "22222222"
+}
+
+### 회원탈퇴
+DELETE http://localhost:8080/member/withdraw
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ1c2VyQGVtYWlsLmNvbSIsInJvbGVzIjpbeyJhdXRob3JpdHkiOiJST0xFX0FETUlOIn1dLCJpYXQiOjE2OTEzMDcxNTYsImV4cCI6MTY5MTMxMDc1Nn0.yPrjbtNq5eVVI1rKzlgYI6K65x6LHzdLtwOdQuvH2SSO1z3Hly-y1u2oeBeE-Yt2xvxORRaxqNCDKaZfYQHnmA
+
+{
+  "password": "22222222"
+}

--- a/src/test/java/com/backend/TravelGuide/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/backend/TravelGuide/member/controller/MemberControllerTest.java
@@ -1,0 +1,225 @@
+package com.backend.TravelGuide.member.controller;
+
+import com.backend.TravelGuide.member.domain.MemberRequestDTO;
+import com.backend.TravelGuide.member.domain.MemberResponseDTO;
+import com.backend.TravelGuide.member.service.impl.MemberServiceImpl;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.hibernate.annotations.Check;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.security.Principal;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class MemberControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MemberServiceImpl memberService;
+
+    @Mock
+    private Principal principal;
+
+    @InjectMocks
+    private MemberController memberController;
+
+    private static final String jwt =
+            "Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ1c2VyQGVtYWlsLmNvbSIsInJvbGVzIjpbeyJhdXRob3JpdHkiOiJST0xFX1VTRVIifV0sImlhdCI6MTY5MTMwNjMwNywiZXhwIjoxNjkxMzA5OTA3fQ.VnY_R6q1KxdGHAq3spewbTZRbduhB16QDJf4cOGwGKk_YGQ9VME2pvqmIMbusi_8_HPWpIl0-_ZP8Q2Di9lLew";
+
+    @Test
+    @DisplayName("회원가입 컨트롤러 테스트")
+    void testJoin() throws Exception {
+        // given
+        MemberRequestDTO.MemberJoinDTO joinDTO = MemberRequestDTO.MemberJoinDTO
+                .builder()
+                .email("user@email.com")
+                .name("user")
+                .password("11111111")
+                .answers(Arrays.asList("answer1", "answer2", "answer3"))
+                .build();
+
+        // when
+        doNothing().when(memberService).join(any());
+
+        // then
+        mockMvc.perform(post("/member/join")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(new ObjectMapper().writeValueAsString(joinDTO)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("비밀번호 찾기 대답 확인 컨트롤러 테스트")
+    void testCheckAnswer() throws Exception {
+        // given
+        MemberRequestDTO.CheckAnswerDTO checkAnswerDTO =
+                MemberRequestDTO.CheckAnswerDTO
+                        .builder()
+                        .email("user@email.com")
+                        .name("user")
+                        .questionId(1)
+                        .answer("answer1")
+                        .build();
+
+        // when
+        when(memberService.checkAnswer(any())).thenReturn(true);
+
+        // then
+        mockMvc.perform(get("/member/checkAnswer")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(new ObjectMapper().writeValueAsString(checkAnswerDTO)))
+                .andExpect(status().isOk())
+                .andExpect(content().string("true"));
+    }
+
+    @Test
+    @DisplayName("새 비밀번호 세팅 컨트롤러 테스트")
+    void testNewPassword() throws Exception {
+        // given
+        MemberRequestDTO.NewPasswordDTO newPasswordDTO =
+                MemberRequestDTO.NewPasswordDTO
+                        .builder()
+                        .email("user@email.com")
+                        .newPassword("22222222")
+                        .build();
+
+        // when
+        doNothing().when(memberService).setNewPassword(newPasswordDTO);
+
+        // then
+        mockMvc.perform(post("/member/newPassword")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(new ObjectMapper().writeValueAsString(newPasswordDTO)))
+                .andExpect(status().isOk());
+
+    }
+    @Test
+    @DisplayName("회원정보조회 컨트롤러 테스트")
+    void testInfo() throws Exception {
+        // given
+        MemberResponseDTO.MemberInformationDTO infoDTO = MemberResponseDTO.MemberInformationDTO
+                        .builder()
+                        .email("user@email.com")
+                        .name("user")
+                        .build();
+
+        given(principal.getName()).willReturn("user@email.com");
+
+        // when
+        when(memberService.searchInfo(anyString())).thenReturn(infoDTO);
+
+        // then
+        mockMvc.perform(get("/member/info")
+                .header("Authorization", jwt)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.email").value("user@email.com"))
+                .andExpect(jsonPath("$.name").value("user"));
+    }
+
+    @Test
+    @DisplayName("회원정보수정 컨트롤러 테스트")
+    void testUpdate() throws Exception {
+        // given
+        MemberRequestDTO.UpdateInfoDTO updateInfoDTO = MemberRequestDTO.UpdateInfoDTO.builder()
+                .email("user@email.com")
+                .name("modified user")
+                .build();
+
+        // when
+        when(principal.getName()).thenReturn("user@email.com");
+        doNothing().when(memberService).updateInfo(any());
+
+        // then
+        mockMvc.perform(put("/member/update")
+                .header("Authorization", jwt)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(new ObjectMapper().writeValueAsString(updateInfoDTO)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("비밀번호 초기화 컨트롤러 테스트")
+    void testPassword() throws Exception {
+        // given
+        MemberRequestDTO.ResetPwdDTO resetPwdDTO = MemberRequestDTO.ResetPwdDTO
+                .builder()
+                .email("user@email.com")
+                .oldPassword("11111111")
+                .newPassword("22222222")
+                .build();
+
+        // when
+        doNothing().when(memberService).resetPassword(resetPwdDTO);
+
+        // then
+        mockMvc.perform(put("/member/password_reset")
+                .header("Authorization", jwt)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(new ObjectMapper().writeValueAsString(resetPwdDTO)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("회원탈퇴 컨트롤러 테스트")
+    void testWithdraw() throws Exception {
+        // given
+        MemberRequestDTO.WithdrawDTO withdrawDTO = MemberRequestDTO.WithdrawDTO
+                .builder()
+                .email("user@email.com")
+                .password("11111111")
+                .build();
+
+        // when
+        when(principal.getName()).thenReturn("user@email.com");
+        doNothing().when(memberService).withdraw(any());
+
+        // then
+        mockMvc.perform(delete("/member/withdraw")
+                .header("Authorization", jwt)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(new ObjectMapper().writeValueAsString(withdrawDTO)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("이메일/닉네인 중복검사 컨트롤러 테스트")
+    void testDuplication() throws Exception {
+        // given
+        MemberRequestDTO.CheckDuplicationDTO duplicationDTO =
+                MemberRequestDTO.CheckDuplicationDTO
+                        .builder()
+                        .email("user@email.com")
+                        .build();
+
+        // when
+        when(memberService.isDuplicated(any())).thenReturn(true);
+
+        // then
+        mockMvc.perform(get("/member/duplication")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(new ObjectMapper().writeValueAsString(duplicationDTO)))
+                .andExpect(status().isOk())
+                .andExpect(content().string("true"));
+    }
+}

--- a/src/test/java/com/backend/TravelGuide/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/backend/TravelGuide/member/repository/MemberRepositoryTest.java
@@ -1,0 +1,119 @@
+package com.backend.TravelGuide.member.repository;
+
+import com.backend.TravelGuide.member.domain.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@ExtendWith(SpringExtension.class)
+class MemberRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Test
+    @DisplayName("existsByEmail 쿼리메소드 테스트")
+    void testExistsByEmail() {
+        // given
+        Member member = Member.builder()
+                .email("user@email.com")
+                .build();
+
+        entityManager.persist(member);
+        entityManager.flush();
+
+        // when
+        boolean result = memberRepository.existsByEmail("user@email.com");
+
+        // then
+        assertTrue(result);
+    }
+
+    @Test
+    @DisplayName("existsByNickname 쿼리메소드 테스트")
+    void testExistsByNickname() {
+        // given
+        Member member = Member.builder()
+                .email("user@email.com")
+                .nickname("user")
+                .build();
+
+        entityManager.persist(member);
+        entityManager.flush();
+
+        // when
+        boolean result = memberRepository.existsByNickname("user");
+
+        // then
+        assertTrue(result);
+    }
+
+    @Test
+    @DisplayName("findByEmailAndName 쿼리메소드 테스트")
+    void testFindByEmailAndName() {
+        // given
+        Member member = Member.builder()
+                .email("user@email.com")
+                .name("user")
+                .build();
+
+        entityManager.persist(member);
+        entityManager.flush();
+
+        // when
+        Optional<Member> optionalMember = memberRepository.findByEmailAndName("user@email.com", "user");
+
+        // then
+        assertTrue(optionalMember.isPresent());
+    }
+
+    @Test
+    @DisplayName("findByEmail 쿼리메소드 테스트")
+    void testFindByEmail() {
+        // given
+        Member member = Member.builder()
+                .email("user@email.com")
+                .build();
+
+        entityManager.persist(member);
+        entityManager.flush();
+
+        // when
+        Optional<Member> optionalMember = memberRepository.findByEmail("user@email.com");
+
+        // then
+        assertTrue(optionalMember.isPresent());
+    }
+
+    @Test
+    @DisplayName("findByEmailAndFromSocial 쿼리메소드 테스트")
+    void testFindByEmailAndFromSocial() {
+        // given
+        Member member = Member.builder()
+                .email("user@email.com")
+                .fromSocial(false)
+                .build();
+
+        entityManager.persist(member);
+        entityManager.flush();
+
+        // when
+        Optional<Member> optionalMember =
+                memberRepository.findByEmailAndFromSocial("user@email.com", false);
+
+        // then
+        assertTrue(optionalMember.isPresent());
+    }
+}

--- a/src/test/java/com/backend/TravelGuide/member/service/MemberServiceTest.java
+++ b/src/test/java/com/backend/TravelGuide/member/service/MemberServiceTest.java
@@ -1,0 +1,463 @@
+package com.backend.TravelGuide.member.service;
+
+import com.backend.TravelGuide.member.domain.Member;
+import com.backend.TravelGuide.member.domain.MemberRequestDTO;
+import com.backend.TravelGuide.member.domain.MemberResponseDTO;
+import com.backend.TravelGuide.member.domain.Role;
+import com.backend.TravelGuide.member.error.exception.PasswordNotMatchException;
+import com.backend.TravelGuide.member.error.exception.UserAlreadyExistsException;
+import com.backend.TravelGuide.member.repository.MemberRepository;
+import com.backend.TravelGuide.member.service.impl.MemberServiceImpl;
+import org.hibernate.annotations.Check;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.security.Principal;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(SpringExtension.class)
+class MemberServiceTest {
+
+    private final String email = "user@email.com";
+    private final String name = "user";
+    private final String nickname = "user";
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private Principal principal;
+
+    @InjectMocks
+    private MemberServiceImpl memberService;
+
+    private Member createMember() {
+        Map<Integer, String> answerMap = new HashMap<>();
+        answerMap.put(1, "answer1");
+        answerMap.put(2, "answer2");
+
+        return Member.builder()
+                .email(email)
+                .name(name)
+                .nickname(nickname)
+                .password("11111111")
+                .role(Role.USER)
+                .answers(answerMap)
+                .build();
+    }
+
+    @Test
+    @DisplayName("회원가입 테스트")
+    void testJoin() {
+        // given
+        given(memberRepository.existsByEmail(anyString()))
+                .willReturn(false);
+
+        MemberRequestDTO.MemberJoinDTO joinDTO =
+                MemberRequestDTO.MemberJoinDTO.builder()
+                        .email("user@email.com")
+                        .password("1111")
+                        .name("user")
+                        .nickname("user")
+                        .answers(Arrays.asList("answer1", "answer2"))
+                        .build();
+
+        // when
+        memberService.join(joinDTO);
+
+        // then
+        verify(memberRepository, times(1)).save(any(Member.class));
+        ArgumentCaptor<Member> memberCaptor = ArgumentCaptor.forClass(Member.class);
+        verify(memberRepository).save(memberCaptor.capture());
+
+        Member savedMember = memberCaptor.getValue();
+        assertEquals(savedMember.getEmail(), joinDTO.getEmail());
+        assertEquals(savedMember.getName(), joinDTO.getName());
+        assertEquals(savedMember.getNickname(), joinDTO.getNickname());
+        assertEquals(savedMember.getAnswers().size(), joinDTO.getAnswers().size());
+    }
+
+    @Test
+    @DisplayName("회원가입시 이미 존재하는 아이디일경우 예외 발생 테스트")
+    void testJoin_UserAlreadyExistsException() {
+        // given
+        MemberRequestDTO.MemberJoinDTO joinDTO = MemberRequestDTO.MemberJoinDTO.builder()
+                .email("user@email.com")
+                .password("1111")
+                .name("user")
+                .build();
+
+        // when
+        when(memberRepository.existsByEmail(anyString()))
+                .thenReturn(true);
+
+        // then
+        assertThrows(UserAlreadyExistsException.class, () -> memberService.join(joinDTO));
+    }
+
+    @Test
+    @DisplayName("회원정보조회 테스트")
+    void testSearchInfo() {
+        // given
+        Member member = createMember();
+
+        given(principal.getName()).willReturn("user@email.com");
+
+        given(memberRepository.findByEmail(anyString()))
+                .willReturn(Optional.of(member));
+
+        // when
+        MemberResponseDTO.MemberInformationDTO informationDTO =
+                memberService.searchInfo("user@email.com");
+
+        // then
+        assertEquals(informationDTO.getEmail(), "user@email.com");
+        assertEquals(informationDTO.getName(), "user");
+        assertEquals(informationDTO.getNickname(), "user");
+    }
+
+    @Test
+    @DisplayName("회원정보조회시 로그인한 사용자의 이메일과 일치하지 않을 경우 예외 발생 테스트")
+    void testSearchInfo_UserNotMatchException() {
+        // given
+        when(memberRepository.findByEmail(anyString())).thenReturn(Optional.empty());
+
+        // when
+        // then
+        assertThrows(UsernameNotFoundException.class,
+                () -> memberService.searchInfo("user@email.com"));
+    }
+
+    @Test
+    @DisplayName("회원정보조회시 해당 이메일의 회원이 존재하지 않을경우 예외 발생 테스트")
+    void testSearchInfo_UsernameNotFoundException() {
+        // given
+        given(principal.getName()).willReturn("user@email.com");
+
+        given(memberRepository.findByEmail(anyString()))
+                .willReturn(Optional.empty());
+
+        // when
+        // then
+        assertThrows(UsernameNotFoundException.class,
+                () -> memberService.searchInfo("user@email.com"));
+    }
+
+    @Test
+    @DisplayName("회원정보수정 테스트")
+    void testUpdateInfo() {
+        // given
+        Member member = createMember();
+
+        MemberRequestDTO.UpdateInfoDTO updateInfoDTO = MemberRequestDTO.UpdateInfoDTO
+                .builder()
+                .email(email)
+                .name("modified_user")
+                .nickname("modified_user")
+                .build();
+
+        given(memberRepository.findByEmail(anyString())).willReturn(Optional.of(member));
+
+        // when
+        memberService.updateInfo(updateInfoDTO);
+
+        // then
+        verify(memberRepository, times(1)).save(any(Member.class));
+        ArgumentCaptor<Member> memberCaptor = ArgumentCaptor.forClass(Member.class);
+        verify(memberRepository).save(memberCaptor.capture());
+
+        Member savedMember = memberCaptor.getValue();
+        assertEquals(savedMember.getNickname(), updateInfoDTO.getNickname());
+    }
+
+    @Test
+    @DisplayName("회원정보수정시 해당 이메일의 회원이 존재하지 않을 경우 예외 발생 테스트")
+    void testUpdateInfo_UsernameNotFoundException() {
+        // given
+        MemberRequestDTO.UpdateInfoDTO updateInfoDTO =
+                MemberRequestDTO.UpdateInfoDTO.builder()
+                        .email("user@email.com")
+                        .name("user")
+                        .build();
+
+        // when
+        when(memberRepository.findByEmail(anyString()))
+                .thenReturn(Optional.empty());
+
+        // then
+        assertThrows(UsernameNotFoundException.class,
+                () -> memberService.updateInfo(updateInfoDTO));
+    }
+
+    @Test
+    @DisplayName("비밀번호 초기화 테스트")
+    void testResetPassword() {
+        // given
+        Member member = createMember();
+
+        MemberRequestDTO.ResetPwdDTO resetPwdDTO = MemberRequestDTO.ResetPwdDTO.builder()
+                .email(email)
+                .oldPassword("11111111")
+                .newPassword("22222222")
+                .build();
+
+        given(memberRepository.findByEmail(anyString())).willReturn(Optional.of(member));
+        given(passwordEncoder.matches(anyString(), anyString())).willReturn(true);
+
+        // when
+        memberService.resetPassword(resetPwdDTO);
+
+        // then
+        verify(memberRepository, times(1)).save(any(Member.class));
+    }
+
+    @Test
+    @DisplayName("비밀번호 초기화시 해당 이메일의 회원이 존재하지 않을경우 예외 발생 테스트")
+    void testResetPassword_UsernameNotFoundException() {
+        // given
+        MemberRequestDTO.ResetPwdDTO resetPwdDTO = MemberRequestDTO.ResetPwdDTO.builder()
+                .email("user@email.com")
+                .oldPassword("1111")
+                .newPassword("2222")
+                .build();
+
+        // when
+        when(memberRepository.findByEmail(anyString()))
+                .thenReturn(Optional.empty());
+
+        // then
+        assertThrows(UsernameNotFoundException.class,
+                () -> memberService.resetPassword(resetPwdDTO));
+    }
+
+    @Test
+    @DisplayName("비밀번호 초기화시 비밀번호가 일치하지 않을 경우 예외 발생 테스트")
+    void testResetPassword_PasswordNotMatchException() {
+        // given
+        MemberRequestDTO.ResetPwdDTO resetPwdDTO = MemberRequestDTO.ResetPwdDTO.builder()
+                .email("user@email.com")
+                .oldPassword("1111")
+                .newPassword("2222")
+                .build();
+
+        Member member = createMember();
+
+        // when
+        when(memberRepository.findByEmail(anyString()))
+                .thenReturn(Optional.of(member));
+
+        when(passwordEncoder.matches(anyString(), anyString()))
+                .thenReturn(false);
+
+        // then
+        assertThrows(PasswordNotMatchException.class,
+                () -> memberService.resetPassword(resetPwdDTO));
+    }
+
+    @Test
+    @DisplayName("비밀번호 찾기 질문에 대한 대답 검사")
+    void testCheckAnswer() {
+        // given
+        Member member = createMember();
+
+        MemberRequestDTO.CheckAnswerDTO answerDTO = MemberRequestDTO.CheckAnswerDTO
+                .builder()
+                .email(email)
+                .name(name)
+                .questionId(2)
+                .answer("answer2")
+                .build();
+
+        given(memberRepository.findByEmailAndName(email, name))
+                .willReturn(Optional.of(member));
+
+        // when
+        boolean result = memberService.checkAnswer(answerDTO);
+
+        // then
+        assertTrue(result);
+    }
+
+    @Test
+    @DisplayName("비밀번호 찾기 질문에 대한 대답 검사시 회원이 존재하지 않을 경우 예외 발생 테스트")
+    void testCheckAnswer_UsernameNotFoundException() {
+        // given
+        MemberRequestDTO.CheckAnswerDTO answerDTO = MemberRequestDTO.CheckAnswerDTO
+                .builder()
+                .email(email)
+                .name(name)
+                .questionId(2)
+                .answer("answer2")
+                .build();
+
+        // when
+        when(memberRepository.findByEmailAndName(anyString(), anyString()))
+                .thenReturn(Optional.empty());
+
+        // then
+        assertThrows(UsernameNotFoundException.class, () -> memberService.checkAnswer(answerDTO));
+    }
+
+    @Test
+    @DisplayName("비밀번호 찾기 질문을 통과한후 새로운 비밀번호 등록 테스트")
+    void testSetNewPassword() {
+        // given
+        Member member = createMember();
+
+        MemberRequestDTO.NewPasswordDTO newPasswordDTO = MemberRequestDTO.NewPasswordDTO
+                .builder()
+                .email(email)
+                .newPassword("22222222")
+                .build();
+
+        given(memberRepository.findByEmail(anyString())).willReturn(Optional.of(member));
+
+        // when
+        memberService.setNewPassword(newPasswordDTO);
+
+        // then
+        verify(memberRepository, times(1)).save(any(Member.class));
+    }
+
+    @Test
+    @DisplayName("비밀번호 찾기 질문을 통과한후 새로운 비밀번호 등록시 회원이 존재하지 않을 경우 예외 발생 테스트")
+    void testSetNewPassword_UsernameNotFoundException() {
+        // given
+        MemberRequestDTO.NewPasswordDTO newPasswordDTO = MemberRequestDTO.NewPasswordDTO
+                .builder()
+                .email(email)
+                .newPassword("22222222")
+                .build();
+
+        // when
+        when(memberRepository.findByEmail(anyString())).thenReturn(Optional.empty());
+
+        // then
+        assertThrows(UsernameNotFoundException.class,
+                () -> memberService.setNewPassword(newPasswordDTO));
+    }
+
+    @Test
+    @DisplayName("회원탈퇴 테스트")
+    void testWithdraw() {
+        // given
+        Member member = Member.builder()
+                .email(email)
+                .password("$2a$10$qhSeIwUoC2aipwkv7tHDm.AfmWw/L0ncXSHewdT7rS3d4GHnRpAcO")
+                .build();
+
+        MemberRequestDTO.WithdrawDTO withdrawDTO = MemberRequestDTO.WithdrawDTO
+                        .builder()
+                        .email(email)
+                        .password("1111")
+                        .build();
+
+        given(memberRepository.findByEmail(anyString())).willReturn(Optional.of(member));
+
+        given(passwordEncoder.matches(anyString(), anyString())).willReturn(true);
+
+        // when
+        memberService.withdraw(withdrawDTO);
+
+        // then
+        verify(memberRepository, times(1)).delete(member);
+    }
+
+    @Test
+    @DisplayName("회원탈퇴시 존재하지 않는 회원일경우 예외 발생 테스트")
+    void testWithdraw_UsernameNotFoundException() {
+        // given
+        MemberRequestDTO.WithdrawDTO withdrawDTO = MemberRequestDTO.WithdrawDTO
+                .builder()
+                .email("user@email.com")
+                .password("1111")
+                .build();
+
+        // when
+        when(memberRepository.findByEmail(anyString()))
+                .thenReturn(Optional.empty());
+
+        // then
+        assertThrows(UsernameNotFoundException.class,
+                () -> memberService.withdraw(withdrawDTO));
+    }
+
+    @Test
+    @DisplayName("회원탈퇴시 비밀번호가 일치하지 않을 경우 예외 발생 테스트")
+    void testWithdraw_PasswordNotMatchException() {
+        // given
+        Member member = createMember();
+
+        MemberRequestDTO.WithdrawDTO withdrawDTO = MemberRequestDTO.WithdrawDTO
+                .builder()
+                .email("user@email.com")
+                .password("2222")
+                .build();
+
+        // when
+        when(memberRepository.findByEmail(anyString()))
+                .thenReturn(Optional.of(member));
+
+        when(passwordEncoder.matches(anyString(), anyString()))
+                .thenReturn(false);
+
+        // then
+        assertThrows(PasswordNotMatchException.class,
+                () -> memberService.withdraw(withdrawDTO));
+    }
+
+    @Test
+    @DisplayName("이메일 중복 검사 테스트")
+    void testIsEmailDuplicated() {
+        // given
+        MemberRequestDTO.CheckDuplicationDTO duplicationDTO = MemberRequestDTO.CheckDuplicationDTO
+                .builder()
+                .email(email)
+                .build();
+
+        given(memberRepository.existsByEmail(anyString())).willReturn(true);
+
+        // when
+        boolean result = memberService.isDuplicated(duplicationDTO);
+
+        // then
+        assertFalse(result);
+    }
+
+    @Test
+    @DisplayName("닉네임 중복 검사 테스트")
+    void testIsNicknameDuplicated() {
+        // given
+        MemberRequestDTO.CheckDuplicationDTO duplicationDTO = MemberRequestDTO.CheckDuplicationDTO
+                .builder()
+                .nickname(nickname)
+                .build();
+
+        given(memberRepository.existsByNickname(anyString())).willReturn(true);
+
+        // when
+        boolean result = memberService.isDuplicated(duplicationDTO);
+
+        // then
+        assertFalse(result);
+    }
+}


### PR DESCRIPTION
feat:[001-Member] - 회원 관련 컨트롤러/서비스/레포지토리 클래스 생성 및 테스트 코드 작성 

- 회원엔티티, 관련 도메인 파일 생성, 컨트롤러, 서비스, repository 쿼리 메소드 생성
- 회원가입, 사용자 정보 조회, 사용자 정보 수정, 비밀번호 초기화, 회원탈퇴, 이메일/닉네임 중복 검사, 비밀번호 찾기 질문의 답변 확인 기능 구현
- 카카오 회원 로그인시 로그인한적이 없을 경우 회원가입 후 JWT 토큰 반환
- 일반 회원 로그인시 JWT 토큰 반환
- 로그인이 필요한 서비스들은 엔드포인트 호출시 JWT 토큰 검사